### PR TITLE
fix: Set default card date to empty

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,3 +1,8 @@
+## 2025-07-14
+
+### Bug Fixes
+- Set the default date for new cards to empty instead of the current date.
+
 ## 2025-07-13
 
 ### Bug Fixes

--- a/src/components/MainBoard.jsx
+++ b/src/components/MainBoard.jsx
@@ -234,7 +234,7 @@ const MainBoard = ({ user }) => {
       title: title,
       priority: false,
       tags: [],
-      date: new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+      date: '',
       completed: false,
     };
     const newColumns = columns.map(col => {


### PR DESCRIPTION
Newly created cards will no longer have the current date assigned by default. This allows users to explicitly set a date if needed.