### PR TITLE
Feature/admin-dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,6 @@ VITE_FIREBASE_MEASUREMENT_ID=your-measurement-id
 E2E_EMAIL=test-user@example.com
 E2E_PASSWORD=your-test-password
 
-# Admin
-VITE_ADMIN_UID=your-admin-uid
+# Admin claim script (one of these)
+FIREBASE_SERVICE_ACCOUNT=path/to/serviceAccount.json
+# FIREBASE_SERVICE_ACCOUNT_JSON={"type":"service_account",...}

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ VITE_FIREBASE_MEASUREMENT_ID=your-measurement-id
 # E2E (Playwright)
 E2E_EMAIL=test-user@example.com
 E2E_PASSWORD=your-test-password
+
+# Admin
+VITE_ADMIN_UID=your-admin-uid

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ pnpm-lock.yaml
 # Firebase local files
 .firebase/
 test-results/
+*serviceAccount*.json

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -14,6 +14,10 @@
 - **Lane Ordering:** Lanes automatically reorder on load based on WIP, then Planned, then empty lanes.
 ### Tests
 - Added E2E coverage for lane auto ordering with cleanup logic.
+### Features
+- **Admin Dashboard:** Added admin-only metrics dashboard and user activity tracking.
+### Tests
+- Added admin dashboard E2E test with strict console error checks.
 
 ## 2025-11-25
 ### Bug Fixes

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -18,6 +18,8 @@
 - **Admin Dashboard:** Added admin-only metrics dashboard and user activity tracking.
 ### Tests
 - Added admin dashboard E2E test with strict console error checks.
+### Tooling & Security
+- Added Firebase Admin claim helper script, claim-based rule file, and documented claim flow.
 
 ## 2025-11-25
 ### Bug Fixes

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -18,6 +18,7 @@ This project includes an end-to-end test that reproduces the drag-and-drop regre
 - Local dev server (Playwright can start it for you).
 - Set required env vars in `.env` (see `.env.example` for placeholders).
 - If the password contains `#`, wrap it in quotes or escape it so dotenv parses it correctly.
+- Admin dashboard tests require an `admin` custom claim on the test user (see below).
 
 ## Install and run
 
@@ -42,3 +43,23 @@ E2E_PASSWORD="XjnAXR8@e4X#PR"
 
 - The test creates cards and renames the first two lanes for stability.
 - Use a dedicated test account to avoid polluting real data.
+- Admin dashboard checks are gated by an `admin` custom claim on the user.
+- Keep service account JSON outside the repo (e.g., `~/.config/firebase/`) and never commit it.
+
+## Admin Claim Flow
+
+The admin dashboard is now gated by a Firebase Auth custom claim named `admin`.
+
+1) Grant the claim (requires a Firebase service account):
+
+```bash
+FIREBASE_SERVICE_ACCOUNT=/path/to/serviceAccount.json npm run admin:claim -- <uid> grant
+```
+
+2) Revoke the claim when done:
+
+```bash
+FIREBASE_SERVICE_ACCOUNT=/path/to/serviceAccount.json npm run admin:claim -- <uid> revoke
+```
+
+After changing claims, sign out/in (or refresh) so the client receives the updated token.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,4 @@
+# Commit workflow
+
+When asked to commit, always follow two-steps approach. First follow the instructions in docs/commit-workflow.md, the ask user to confirm the commit. Never ever commit without user permission.
+

--- a/e2e/admin-dashboard.spec.js
+++ b/e2e/admin-dashboard.spec.js
@@ -27,6 +27,7 @@ test.describe('admin dashboard', () => {
   test.skip(!email || !password, 'E2E_EMAIL and E2E_PASSWORD are required to run this test.');
 
   test('renders dashboard without console errors', async ({ page }) => {
+    // Requires the test user to have the Firebase Auth custom claim: admin=true.
     const consoleErrors = [];
     const pageErrors = [];
     page.on('console', msg => {

--- a/e2e/admin-dashboard.spec.js
+++ b/e2e/admin-dashboard.spec.js
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+const email = process.env.E2E_EMAIL;
+const password = process.env.E2E_PASSWORD;
+
+async function login(page) {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Sign In with Email/Password' }).click();
+  await page.getByPlaceholder('Email').fill(email);
+  await page.getByPlaceholder('Password').fill(password);
+  await page.getByRole('button', { name: 'Login' }).click();
+
+  const signedIn = page.getByText('Signed in as');
+  const authError = page.locator('.error-message');
+  await Promise.race([
+    signedIn.waitFor({ state: 'visible', timeout: 15000 }),
+    authError.waitFor({ state: 'visible', timeout: 15000 }),
+  ]);
+  if (await authError.isVisible()) {
+    const message = (await authError.textContent()) || 'Unknown auth error';
+    throw new Error(`Login failed: ${message.trim()}`);
+  }
+  await expect(signedIn).toBeVisible();
+}
+
+test.describe('admin dashboard', () => {
+  test.skip(!email || !password, 'E2E_EMAIL and E2E_PASSWORD are required to run this test.');
+
+  test('renders dashboard without console errors', async ({ page }) => {
+    const consoleErrors = [];
+    const pageErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error' || msg.type() === 'warning') {
+        consoleErrors.push(msg.text());
+      }
+    });
+    page.on('pageerror', err => {
+      pageErrors.push(err.message || String(err));
+    });
+
+    await login(page);
+
+    const dashboard = page.getByRole('heading', { name: 'Admin Dashboard' });
+    await expect(dashboard).toBeVisible();
+
+    const dashboardError = page.getByText('Failed to load admin metrics.');
+    await expect(dashboardError).toHaveCount(0, { timeout: 10000 });
+
+    await page.waitForTimeout(2000);
+
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+  });
+});

--- a/firebase.json
+++ b/firebase.json
@@ -9,5 +9,8 @@
     "frameworksBackend": {
       "region": "europe-west1"
     }
+  },
+  "firestore": {
+    "rules": "firestore.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,18 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isAdmin() {
+      return request.auth != null && request.auth.token.admin == true;
+    }
+
+    match /boards/{userId} {
+      allow read: if request.auth != null && (request.auth.uid == userId || isAdmin());
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /users/{userId} {
+      allow read: if request.auth != null && (request.auth.uid == userId || isAdmin());
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "node --test",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "admin:claim": "node scripts/setAdminClaim.js",
     "preview": "vite preview",
     "deploy": "firebase deploy --only hosting"
   },
@@ -34,6 +35,7 @@
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
     "dotenv": "^17.0.0",
+    "firebase-admin": "^13.4.0",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",

--- a/scripts/setAdminClaim.js
+++ b/scripts/setAdminClaim.js
@@ -1,0 +1,60 @@
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+
+const resolveServiceAccount = () => {
+  const envPath = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envPath) {
+    const cleaned = envPath.replace(/^['"]|['"]$/g, '');
+    const expanded = cleaned.startsWith('~')
+      ? path.join(process.env.HOME || '', cleaned.slice(1))
+      : cleaned;
+    const fullPath = path.resolve(expanded);
+    return JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+  }
+
+  const jsonEnv = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  if (jsonEnv) {
+    return JSON.parse(jsonEnv);
+  }
+
+  throw new Error('Set FIREBASE_SERVICE_ACCOUNT (path) or FIREBASE_SERVICE_ACCOUNT_JSON (json).');
+};
+
+const uid = process.argv[2];
+const mode = process.argv[3] || 'grant';
+
+if (!uid) {
+  console.error('Usage: node scripts/setAdminClaim.js <uid> [grant|revoke]');
+  process.exit(1);
+}
+
+if (!['grant', 'revoke'].includes(mode)) {
+  console.error('Mode must be grant or revoke.');
+  process.exit(1);
+}
+
+const serviceAccount = resolveServiceAccount();
+initializeApp({ credential: cert(serviceAccount) });
+
+const auth = getAuth();
+
+const run = async () => {
+  const user = await auth.getUser(uid);
+  const claims = user.customClaims || {};
+  if (mode === 'grant') {
+    claims.admin = true;
+  } else {
+    delete claims.admin;
+  }
+  await auth.setCustomUserClaims(uid, claims);
+  console.log(`Admin claim ${mode}ed for uid: ${uid}`);
+};
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import { collection, getCountFromServer, getDocs, query, where } from 'firebase/firestore';
+import { db } from '../firebase.js';
+
+const oneWeekAgo = () => new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+const AdminDashboard = ({ user }) => {
+  const [stats, setStats] = useState({
+    totalUsers: 0,
+    activeUsers: 0,
+    totalBoards: 0,
+    totalLanes: 0,
+    totalCards: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadStats = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const usersRef = collection(db, 'users');
+        const boardsRef = collection(db, 'boards');
+
+        const [usersCount, boardsCount] = await Promise.all([
+          getCountFromServer(usersRef),
+          getCountFromServer(boardsRef),
+        ]);
+
+        const activeQuery = query(usersRef, where('lastActive', '>=', oneWeekAgo()));
+        const activeCount = await getCountFromServer(activeQuery);
+
+        const boardsSnap = await getDocs(boardsRef);
+        let totalLanes = 0;
+        let totalCards = 0;
+
+        boardsSnap.forEach(docSnap => {
+          const lanes = docSnap.data().lanes || [];
+          totalLanes += lanes.length;
+          lanes.forEach(lane => {
+            const rows = lane.rows || [];
+            rows.forEach(row => {
+              totalCards += (row.cards || []).length;
+            });
+          });
+        });
+
+        if (isMounted) {
+          setStats({
+            totalUsers: usersCount.data().count || 0,
+            activeUsers: activeCount.data().count || 0,
+            totalBoards: boardsCount.data().count || 0,
+            totalLanes,
+            totalCards,
+          });
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err?.message || 'Failed to load admin metrics.');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    if (user) {
+      loadStats();
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [user]);
+
+  return (
+    <div className="max-w-6xl mx-auto mt-6 mb-8 px-6">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-900">Admin Dashboard</h2>
+          <span className="text-xs text-gray-500">Last 7 days active</span>
+        </div>
+        {loading ? (
+          <div className="mt-4 text-sm text-gray-500">Loading metrics…</div>
+        ) : error ? (
+          <div className="mt-4 text-sm text-red-600">{error}</div>
+        ) : (
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+            <div className="rounded-lg border border-gray-200 p-4">
+              <div className="text-xs uppercase tracking-wide text-gray-500">Registered Users</div>
+              <div className="mt-2 text-2xl font-semibold text-gray-900">{stats.totalUsers}</div>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <div className="text-xs uppercase tracking-wide text-gray-500">Active Users</div>
+              <div className="mt-2 text-2xl font-semibold text-gray-900">{stats.activeUsers}</div>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <div className="text-xs uppercase tracking-wide text-gray-500">Boards</div>
+              <div className="mt-2 text-2xl font-semibold text-gray-900">{stats.totalBoards}</div>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <div className="text-xs uppercase tracking-wide text-gray-500">Lanes</div>
+              <div className="mt-2 text-2xl font-semibold text-gray-900">{stats.totalLanes}</div>
+            </div>
+            <div className="rounded-lg border border-gray-200 p-4">
+              <div className="text-xs uppercase tracking-wide text-gray-500">Cards</div>
+              <div className="mt-2 text-2xl font-semibold text-gray-900">{stats.totalCards}</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboard;


### PR DESCRIPTION
Summary
Switch admin gating to Firebase Auth custom claims.
Add Firestore rules file and claim helper script.
Document claim-based flow and update E2E admin test expectations.
Key Changes
App.jsx: admin check now uses getIdTokenResult(...).claims.admin.
firestore.rules + firebase.json: rules now enforce admin claim access for global reads.
setAdminClaim.js: helper to grant/revoke admin claim (service account required).
admin-dashboard.spec.js: stricter console error checks and claim requirement note.
Docs/ignore: .env.example, .gitignore, e2e-testing.md, CHANGES.md.
Testing
npm run lint (1 warning in useBoard.js: missing mutedColors dependency)
Notes
Use npm run admin:claim -- <uid> grant|revoke with FIREBASE_SERVICE_ACCOUNT.
Deploy rules with firebase deploy --only firestore:rules.